### PR TITLE
fix bug with select_relates for empty result

### DIFF
--- a/src/eorm_db.erl
+++ b/src/eorm_db.erl
@@ -55,6 +55,8 @@ row_to_object(Fields, InRow) ->
         Fields),
     eorm_object:append_linked(Objs, Obj).
 
+select_relates(_Connection, _, []) ->
+    {ok, []};
 select_relates(_Connection, #{expr:=#{extra_query:=[]}}, Objs) ->
     {ok, Objs};
 select_relates(Connection, #{expr:=#{extra_query:=ExtraQuery}} = _State, Objs) ->


### PR DESCRIPTION
If select return empty list, select_relates called anyway, and it crushes on query

`Query#{where => Where#{{RelationKey, in} => Ids}}`

with error 

`invalid_condition, "bindings for 'IN' is empty"`
